### PR TITLE
Prepare integration for 3lc==2.7.1

### DIFF
--- a/utils/loggers/tlc/README.md
+++ b/utils/loggers/tlc/README.md
@@ -37,11 +37,11 @@ The integration uses the YAML file name to resolve to the relevant tables if the
 
 #### 3LC YAML File
 
-For more flexibility and to explicitly select which tables to use, you can use a 3LC YAML file, like the one written during your first run. It should contain keys for the relevant splits (`train` and `val` in most cases), with values set to the 3LC Urls of the corresponding tables. Once your 3LC YAML is populated with these it will look like the following example:
+For more flexibility and to explicitly select which tables to use, you can use a 3LC YAML file, like the one written during your first run. It should contain keys for the relevant splits (`train` and `val` in most cases), with values set to the 3LC Urls of the corresponding tables. Any 3LC Url is supported, which means that tables on S3 can be used as well. Once your 3LC YAML is populated with these it will look like the following example:
 
 ```yaml
-train: my_train_table
-val: my_val_table
+train: path/to/my_train_table  # On disk
+val: s3://path/to/my_val_table # On s3
 ```
 
 In order to train on different revisions, simply change the paths in the file to your desired revision.
@@ -49,8 +49,8 @@ In order to train on different revisions, simply change the paths in the file to
 If you would like to train on the latest revisions, you can add `:latest` to one or both of the paths, and 3LC will find the `Table`s for the latest revision in the same lineage. For the above example, with latest on both, the 3LC YAML would look like this:
 
 ```yaml
-train: my_train_table:latest
-val: my_val_table:latest
+train: path/to/my_train_table:latest
+val: s3://path/to/my_val_table:latest
 ```
 
 ______________________________________________________________________
@@ -80,7 +80,7 @@ val: my_val_table
 Specifying to use the latest revisions instead can be done by adding `:latest` to one or both of these `Url`s:
 
 ```yaml
-train: my_train_table:latest # resolves to the latest revision of my_train_table, which is Edited1BoundingBoxes
+train: my_train_table:latest # resolves to the latest revision of my_train_table, which is Edited2BoundingBoxes
 val: my_val_table:latest # resolves to the latest revision of my_val_table, which is my_val_table
 ```
 
@@ -88,7 +88,7 @@ val: my_val_table:latest # resolves to the latest revision of my_val_table, whic
 
 ### Metrics Collection Only
 
-In some cases it is useful to collect metrics without doing any training, such as when pretrained weights already exist. This is possible by calling `val.py --task collect`.
+In some cases it is useful to collect metrics without doing any training, such as when pretrained weights already exist. This is possible by calling `val.py --task collect`. Provide any other arguments that you would normally use with `val.py` such as those for batch size, image size etc.
 
 ## 3LC Settings
 
@@ -124,11 +124,11 @@ This assumes there exists a 3LC YAML located at `my/tlc/dataset.yaml`.
 
 ### Image Embeddings
 
-Image embeddings can be collected by setting `TLC_IMAGE_EMBEDDINGS_DIM` to 2 or 3, and are based on the output of the spatial pooling function output from the YOLOv5 architectures. Similar images, as seen by the model, tend to be close to each other in this space. In the 3LC Dashboard these embeddings can be visualized, allowing you to find similar images, find imbalances in your dataset and determine if your validation set is representative of your training data (and vice-versa).
+Image embeddings can be collected by setting `TLC_IMAGE_EMBEDDINGS_DIM` to 2 or 3, and are based on the output of the spatial pooling function output from the YOLOv5 architectures. Similar images, as seen by the model, tend to be close to each other in this space. In the 3LC Dashboard these embeddings can be visualized, allowing you to find similar images, imbalances in your dataset and determine if your validation set is representative of your training data (and vice-versa).
 
 ### Loss
 
-Loss can be collected during calls to `train.py` with `TLC_COLLECT_LOSS`. The output is the three (in the single-class case there are only two, since the classification loss is always zero) loss components computed in YOLOv5. These are useful to determine which images are challenging or easy for the model in terms of the three different loss types. The aggregate loss can be computed in the 3LC Dashboard.
+Loss can be collected during calls to `train.py` with `TLC_COLLECT_LOSS`. The output is the three (in the single-class case there are only two, since the classification loss is always zero) loss components for the image, as computed by YOLOv5. These are useful to determine which images are challenging or easy for the model in terms of the three different loss types. The aggregate loss can be computed in the 3LC Dashboard by taking the sum of the three columns.
 
 ## Other output
 

--- a/utils/loggers/tlc/__init__.py
+++ b/utils/loggers/tlc/__init__.py
@@ -1,5 +1,6 @@
 from utils.loggers.tlc.version import check_tlc_version
 
+# Check that at least the minimum required 3lc version is installed before proceeding
 check_tlc_version()
 
 from utils.loggers.tlc.collect import collect_metrics

--- a/utils/loggers/tlc/base.py
+++ b/utils/loggers/tlc/base.py
@@ -211,6 +211,13 @@ class BaseTLCCallback:
 
         self.run.update_metrics(metrics_infos)
 
+        # Remove metrics tables from 3lc object cache
+        for metrics_info in metrics_infos:
+            tlc.ObjectRegistry._delete_object_from_caches(
+                tlc.Url(metrics_info["url"]).to_absolute(self.run.url)
+            )
+
+
     def compute_loss(self, train_out: torch.Tensor, targets: torch.Tensor) -> dict[str, torch.Tensor]:
         """
         Compute loss for the batch.

--- a/utils/loggers/tlc/collect.py
+++ b/utils/loggers/tlc/collect.py
@@ -138,6 +138,10 @@ def collect_metrics(opt: argparse.Namespace) -> None:
     if settings.image_embeddings_dim > 0:
         split_to_reduce_by = "val" if "val" in settings.collection_splits else settings.collection_splits[-1]
         table_url_to_reduce_by = tables[split_to_reduce_by].url
+
+        LOGGER.info(
+            f"{TLC_COLORSTR}Reducing embeddings to {settings.image_embeddings_dim}D with {settings.image_embeddings_reducer}, this may take some time..."
+        )
         run.reduce_embeddings_by_foreign_table_url(
             table_url_to_reduce_by, method=settings.image_embeddings_reducer, n_components=settings.image_embeddings_dim
         )

--- a/utils/loggers/tlc/collect.py
+++ b/utils/loggers/tlc/collect.py
@@ -208,7 +208,6 @@ class TLCCollectionCallback(BaseTLCCallback):
         self.metrics_writer = tlc.MetricsTableWriter(
             run_url=self.run.url,
             foreign_table_url=self.table.url,
-            foreign_table_display_name=self.table.dataset_name,
             column_schemas=self.metrics_schema,
         )
 

--- a/utils/loggers/tlc/collect.py
+++ b/utils/loggers/tlc/collect.py
@@ -21,10 +21,6 @@ import torch
 
 try:
     import tlc
-
-    from utils.loggers.tlc.version import check_tlc_version
-
-    check_tlc_version()
 except ImportError:
     raise ImportError("Install 3LC with `pip install 3lc` to collect metrics.")
 

--- a/utils/loggers/tlc/constants.py
+++ b/utils/loggers/tlc/constants.py
@@ -9,7 +9,7 @@ TLC_COLORSTR = colorstr("3LC: ")
 TLC_TRAIN_PATH = "3lc_train"
 TLC_VAL_PATH = "3lc_val"
 TLC_COLLECT_PATH = "3lc_collect"
-TLC_VERSION_REQUIRED = "2.3.0"
+TLC_VERSION_REQUIRED = "2.7.1"
 
 # Column names
 TRAINING_PHASE = "Training Phase"

--- a/utils/loggers/tlc/dataloaders.py
+++ b/utils/loggers/tlc/dataloaders.py
@@ -208,7 +208,7 @@ class TLCLoadImagesAndLabels(LoadImagesAndLabels):
 
         pbar = iter(table.table_rows)
         if RANK in {-1, 0}:
-            pbar = track(pbar, description=f"Loading data from 3LC Table {table.url.name}", total=len(table))
+            pbar = track(pbar, description=f"Loading data from 3LC Table {table.dataset_name}/{table.url.name}", total=len(table))
 
         # Keep track of which example ids are in use (map from index in the yolo dataset to example id)
         self.example_ids = []

--- a/utils/loggers/tlc/dataloaders.py
+++ b/utils/loggers/tlc/dataloaders.py
@@ -43,7 +43,7 @@ def tlc_table_row_to_yolo_label(row: dict[str, Any]) -> np.ndarray:
 
 
 def create_dataloader(
-    path: tuple[str, tlc.Table, bool],
+    path: tuple[str, tlc.Table, bool, bool],
     imgsz: int,
     batch_size: int,
     stride: int = 32,
@@ -61,6 +61,11 @@ def create_dataloader(
     shuffle: bool = False,
     seed: int = 0,
 ) -> tuple[DataLoader, LoadImagesAndLabels]:
+    """ Create dataloader in the 3LC integration. In addition to the standard behavior, this function also
+    handles 3LC-specific arguments (zero weight exclusion and sampling weights), logging and reading of 
+    other properties required by the 3LC integration logger.
+    
+    """
     if rect and shuffle:
         LOGGER.warning("WARNING ⚠️ --rect is incompatible with DataLoader shuffle, setting shuffle=False")
         shuffle = False

--- a/utils/loggers/tlc/logger.py
+++ b/utils/loggers/tlc/logger.py
@@ -293,7 +293,6 @@ class TLCLogger(BaseTLCCallback):
             self.metrics_writer = tlc.MetricsTableWriter(
                 run_url=self.run.url,
                 foreign_table_url=self.train_table.url,
-                foreign_table_display_name=self.train_table.dataset_name,
                 column_schemas=self.metrics_schema,
             )
             effective_train_size = self.validation_train_loader.dataset.n
@@ -359,7 +358,6 @@ class TLCLogger(BaseTLCCallback):
         self.metrics_writer = tlc.MetricsTableWriter(
             run_url=self.run.url,
             foreign_table_url=self.val_table.url,
-            foreign_table_display_name=self.val_table.dataset_name,
             column_schemas=self.metrics_schema,
         )
         effective_validation_size = self.val_loader.dataset.n

--- a/utils/loggers/tlc/logger.py
+++ b/utils/loggers/tlc/logger.py
@@ -192,18 +192,17 @@ class TLCLogger(BaseTLCCallback):
         self._validation_loader_args = kwargs
 
     def on_train_start(self) -> None:
-        if not self._settings.collection_disable:
-            # Create a 3LC run and log run parameters
-            self.run = tlc.init(project_name=self.train_table.project_name)
+        # Create a 3LC run and log run parameters
+        self.run = tlc.init(project_name=self.train_table.project_name)
 
-            parameters = {k: v for k, v in vars(self.opt).items() if k != "hyp"}
-            parameters["evolve_population"] = str(parameters["evolve_population"])
-            parameters.update(self.hyp)
-            self.run.set_parameters(parameters=parameters)
+        parameters = {k: v for k, v in vars(self.opt).items() if k != "hyp"}
+        parameters["evolve_population"] = str(parameters["evolve_population"])
+        parameters.update(self.hyp)
+        self.run.set_parameters(parameters=parameters)
 
-            self._model.hyp = self.hyp  # Required for losses
-            self._unreduced_loss_fn = TLCComputeLoss(self._model)
-            self._loss_fn = ComputeLoss(self._model)
+        self._model.hyp = self.hyp  # Required for losses
+        self._unreduced_loss_fn = TLCComputeLoss(self._model)
+        self._loss_fn = ComputeLoss(self._model)
 
         # Print 3LC information
         tlc_mc_string = create_tlc_info_string_before_training(

--- a/utils/loggers/tlc/logger.py
+++ b/utils/loggers/tlc/logger.py
@@ -261,6 +261,9 @@ class TLCLogger(BaseTLCCallback):
         :param results: The final aggregate metrics provided by YOLOv5.
         """
         if self._settings.image_embeddings_dim != 0:
+            LOGGER.info(
+            f"{TLC_COLORSTR}Reducing embeddings to {self._settings.image_embeddings_dim}D with {self._settings.image_embeddings_reducer}, this may take some time..."
+        )
             self.run.reduce_embeddings_by_foreign_table_url(
                 self.val_table.url,
                 method=self._settings.image_embeddings_reducer,

--- a/utils/loggers/tlc/settings.py
+++ b/utils/loggers/tlc/settings.py
@@ -115,7 +115,8 @@ class Settings:
             "pacmap",
             "umap",
         ), f"Invalid image embeddings reducer {self.image_embeddings_reducer}."
-        self._check_reducer_available()
+        if self.image_embeddings_dim > 0: # Only check reducer if embeddings are enabled
+            self._check_reducer_available()
 
         # Train / collect specific settings
         self._verify_training(opt) if training else self._verify_collection()

--- a/utils/loggers/tlc/utils.py
+++ b/utils/loggers/tlc/utils.py
@@ -211,14 +211,27 @@ def get_or_create_3lc_table_from_yolo(yolo_yaml_file: tlc.Url | str, split: str,
     yolo_yaml_name = Path(yolo_yaml_file).name
     yolo_yaml_file = str(Path(yolo_yaml_file).resolve())  # Ensure absolute path for resolving Table Url
 
-    # TODO: Add backcompat check - check if table with project name, dataset name and table_name=split exists, if so, use it.
+    # Previously the table name was the split name and now it is "initial", so we need to check for backwards compatibility
+    table_url_backcompatible = tlc.Table._resolve_table_url(
+        table_url=None,
+        root_url=None,
+        project_name=project_name,
+        dataset_name=dataset_name,
+        table_name=split,
+    )
+
+    if table_url_backcompatible.exists():
+        table_name = split
+    else:
+        table_name = "initial"
+    
     try:
         table = tlc.Table.from_yolo(
             dataset_yaml_file=yolo_yaml_file,
             split=split,
             override_split_path=override_split_path,
             structure=None,
-            table_name="initial",
+            table_name=table_name,
             dataset_name=dataset_name,
             project_name=project_name,
             if_exists="raise",
@@ -235,7 +248,7 @@ def get_or_create_3lc_table_from_yolo(yolo_yaml_file: tlc.Url | str, split: str,
             split=split,
             override_split_path=override_split_path,
             structure=None,
-            table_name="initial",
+            table_name=table_name,
             dataset_name=dataset_name,
             project_name=project_name,
             if_exists="reuse",

--- a/utils/loggers/tlc/utils.py
+++ b/utils/loggers/tlc/utils.py
@@ -289,29 +289,28 @@ def check_table_compatibility(table: tlc.Table) -> bool:
     :returns: True if the Table is compatible, False otherwise.
     """
 
-    # TODO: Improve assertion messages
     row_schema = table.row_schema.values
     assert tlc.IMAGE in row_schema, f"Table does not contain an image column {tlc.IMAGE}"
     assert tlc.WIDTH in row_schema, f"Table does not contain a width column {tlc.WIDTH}"
     assert tlc.HEIGHT in row_schema, f"Table does not contain a height column {tlc.HEIGHT}"
     assert tlc.BOUNDING_BOXES in row_schema, "Table does not contain a bounding box column"
-    assert tlc.BOUNDING_BOX_LIST in row_schema[tlc.BOUNDING_BOXES].values, "Bounding box column does not contain a "
-    assert tlc.SAMPLE_WEIGHT in row_schema
-    assert tlc.LABEL in row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values
-    assert tlc.X0 in row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values
-    assert tlc.Y0 in row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values
-    assert tlc.X1 in row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values
-    assert tlc.Y1 in row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values
+    assert tlc.BOUNDING_BOX_LIST in row_schema[tlc.BOUNDING_BOXES].values, "Bounding box column does not contain a bounding box list"
+    assert tlc.SAMPLE_WEIGHT in row_schema, f"Table does not contain a sample weight column {tlc.SAMPLE_WEIGHT}"
+    assert tlc.LABEL in row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values, f"Bounding box list does not contain a label {tlc.LABEL}"
+    assert tlc.X0 in row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values, f"Bounding box list does not contain a center x named {tlc.X0}"
+    assert tlc.Y0 in row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values, f"Bounding box list does not contain a center y named {tlc.Y0}"
+    assert tlc.X1 in row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values, f"Bounding box list does not contain width {tlc.X1}"
+    assert tlc.Y1 in row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values, f"Bounding box list does not contain height {tlc.Y1}"
 
     X0 = row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values[tlc.X0]
     Y0 = row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values[tlc.Y0]
     X1 = row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values[tlc.X1]
     Y1 = row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values[tlc.Y1]
 
-    assert X0.value.number_role == tlc.NUMBER_ROLE_BB_CENTER_X
-    assert Y0.value.number_role == tlc.NUMBER_ROLE_BB_CENTER_Y
-    assert X1.value.number_role == tlc.NUMBER_ROLE_BB_SIZE_X
-    assert Y1.value.number_role == tlc.NUMBER_ROLE_BB_SIZE_Y
+    assert X0.value.number_role == tlc.NUMBER_ROLE_BB_CENTER_X, f"{tlc.X0} has number role {X0.value.number_role}, expected {tlc.NUMBER_ROLE_BB_CENTER_X}"
+    assert Y0.value.number_role == tlc.NUMBER_ROLE_BB_CENTER_Y, f"{tlc.Y0} has number role {Y0.value.number_role}, expected {tlc.NUMBER_ROLE_BB_CENTER_Y}"
+    assert X1.value.number_role == tlc.NUMBER_ROLE_BB_SIZE_X, f"{tlc.X1} has number role {X1.value.number_role}, expected {tlc.NUMBER_ROLE_BB_SIZE_X}"
+    assert Y1.value.number_role == tlc.NUMBER_ROLE_BB_SIZE_Y, f"{tlc.Y1} has number role {Y1.value.number_role}, expected {tlc.NUMBER_ROLE_BB_SIZE_Y}"
 
     return True
 

--- a/utils/loggers/tlc/version.py
+++ b/utils/loggers/tlc/version.py
@@ -4,7 +4,6 @@
 import tlc
 from packaging import version
 
-from utils.general import LOGGER, colorstr
 from utils.loggers.tlc.constants import TLC_VERSION_REQUIRED
 
 def check_tlc_version() -> None:
@@ -16,7 +15,9 @@ def check_tlc_version() -> None:
     installed_version = version.parse(tlc.__version__)
 
     if installed_version < required_version:
-        prefix = colorstr("red", "WARNING: ")
-        LOGGER.warn(f"{prefix}You are using 3lc version {installed_version}, "
-                    f"but the integration is intended for {required_version} or higher. "
-                    "Please upgrade 3lc if you run into problems.")
+        installed_str = ".".join(str(part) for part in installed_version.release[:3])
+        raise ValueError(
+            f"You are using 3lc=={installed_str}. "
+            f"This version of the integration is intended for 3lc>={required_version}. "
+            "Please upgrade 3lc with `pip install --upgrade 3lc`."
+        )


### PR DESCRIPTION
- Fix bug causing 3LC to fail to read some yolo datasets with relative `'path'` in the yaml file.
- Fix bug when parsing 3LC YOLO YAML with an `s3://`-prefix and `:latest`. 
- Only check the `3lc` version and warn if it is too low once.
- Update the required version of `3lc` to `2.7.1`.
- Make schema check output more helpful, giving a hint about what is missing from the `tlc.Table` if it is not compatible with the YOLOv5 integration.
- Check that the model supplied to `val.py --task=collect` is compatible with the provided tables.
- Small improvements to logging.
- Clear metrics tables from cache to reduce memory footprint.
- Create a run and log per-epoch and per-sample metrics to the run when TLC_COLLECTION_DISABLE is true.
- For new tables created with the integration, the `table_name` is now set to `initial` instead of the split it corresponds to.