### PR TITLE
Support more bounding box formats

### DIFF
--- a/utils/loggers/tlc/dataloaders.py
+++ b/utils/loggers/tlc/dataloaders.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import os
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import numpy as np
 import tlc
@@ -16,6 +16,7 @@ from PIL import Image, ImageOps
 from torch.utils.data import DataLoader, distributed
 from tqdm import tqdm
 from tlc.core.utils.progress import track
+from tlc.core.builtins.types.bounding_box import CenteredXYWHBoundingBox
 
 from utils.augmentations import Albumentations
 from utils.dataloaders import InfiniteDataLoader, LoadImagesAndLabels, img2label_paths, seed_worker
@@ -30,12 +31,16 @@ RANK = int(os.getenv("RANK", -1))
 PIN_MEMORY = str(os.getenv("PIN_MEMORY", True)).lower() == "true"  # global pin_memory for dataloaders
 
 
-def unpack_box(bbox: dict[str, Any]) -> list[int | float]:
-    return [bbox[tlc.LABEL], bbox[tlc.X0], bbox[tlc.Y0], bbox[tlc.X1], bbox[tlc.Y1]]
+def unpack_box(bbox: dict[str, Any], bounding_box_factory: Callable[..., tlc.BoundingBox], image_width: int, image_height: int) -> list[int | float]:
+    coordinates = [bbox[tlc.X0], bbox[tlc.Y0], bbox[tlc.X1], bbox[tlc.Y1]]
+
+    xywh_coordinates = CenteredXYWHBoundingBox.from_top_left_xywh(bounding_box_factory(coordinates).to_top_left_xywh().normalize(image_width, image_height))
+
+    return [bbox[tlc.LABEL], *xywh_coordinates]
 
 
-def tlc_table_row_to_yolo_label(row: dict[str, Any]) -> np.ndarray:
-    unpacked = [unpack_box(box) for box in row[tlc.BOUNDING_BOXES][tlc.BOUNDING_BOX_LIST]]
+def tlc_table_row_to_yolo_label(row: dict[str, Any], bounding_box_factory: Callable[..., tlc.BoundingBox], image_width: int, image_height: int) -> np.ndarray:
+    unpacked = [unpack_box(box, bounding_box_factory, image_width, image_height) for box in row[tlc.BOUNDING_BOXES][tlc.BOUNDING_BOX_LIST]]
     arr = np.array(unpacked, ndmin=2, dtype=np.float32)
     if len(unpacked) == 0:
         arr = arr.reshape(0, 5)
@@ -219,6 +224,11 @@ class TLCLoadImagesAndLabels(LoadImagesAndLabels):
         self.example_ids = []
         num_ignored = 0
 
+        try:
+            bounding_box_factory = tlc.BoundingBox.from_schema(table.rows_schema[tlc.BOUNDING_BOXES][tlc.BOUNDING_BOX_LIST])
+        except Exception as e:
+            raise ValueError(f"Error inferring bounding box format for {table.dataset_name}.") from e
+
         for example_id, row in enumerate(pbar):
             im_file = tlc.Url(row[tlc.IMAGE]).to_absolute().to_str()
 
@@ -239,7 +249,7 @@ class TLCLoadImagesAndLabels(LoadImagesAndLabels):
                 self.sampling_weights.append(row[tlc.SAMPLE_WEIGHT])
                 self.im_files.append(str(Path(im_file)))  # Ensure path is os.sep-delimited
                 self.shapes.append((row[tlc.WIDTH], row[tlc.HEIGHT]))
-                self.labels.append(tlc_table_row_to_yolo_label(row))
+                self.labels.append(tlc_table_row_to_yolo_label(row, bounding_box_factory, row[tlc.WIDTH], row[tlc.HEIGHT]))
                 self.example_ids.append(example_id)
 
         self.shapes = np.array(self.shapes)

--- a/utils/loggers/tlc/dataloaders.py
+++ b/utils/loggers/tlc/dataloaders.py
@@ -225,7 +225,7 @@ class TLCLoadImagesAndLabels(LoadImagesAndLabels):
         num_ignored = 0
 
         try:
-            bounding_box_factory = tlc.BoundingBox.from_schema(table.rows_schema[tlc.BOUNDING_BOXES][tlc.BOUNDING_BOX_LIST])
+            bounding_box_factory = tlc.BoundingBox.from_schema(table.rows_schema.values[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST])
         except Exception as e:
             raise ValueError(f"Error inferring bounding box format for {table.dataset_name}.") from e
 

--- a/utils/loggers/tlc/dataloaders.py
+++ b/utils/loggers/tlc/dataloaders.py
@@ -30,11 +30,24 @@ LOCAL_RANK = int(os.getenv("LOCAL_RANK", -1))  # https://pytorch.org/docs/stable
 RANK = int(os.getenv("RANK", -1))
 PIN_MEMORY = str(os.getenv("PIN_MEMORY", True)).lower() == "true"  # global pin_memory for dataloaders
 
+def convert_to_xywh(bbox: tlc.BoundingBox, image_width: int, image_height: int) -> CenteredXYWHBoundingBox:
+    """Convert a bounding box to xc, yc, w, h, normalized to [0, 1].
+    
+    :param bbox: The 3LC bounding box to convert.
+    :param image_width: The width of the image.
+    :param image_height: The height of the image.
+    :return: The bounding box converted to xc, yc, w, h.
+    """
+    if isinstance(bbox, CenteredXYWHBoundingBox) and bbox.normalized:
+        return bbox
+    else:
+        return CenteredXYWHBoundingBox.from_top_left_xywh(bbox.to_top_left_xywh().normalize(image_width, image_height))
+
 
 def unpack_box(bbox: dict[str, Any], bounding_box_factory: Callable[..., tlc.BoundingBox], image_width: int, image_height: int) -> list[int | float]:
     coordinates = [bbox[tlc.X0], bbox[tlc.Y0], bbox[tlc.X1], bbox[tlc.Y1]]
 
-    xywh_coordinates = CenteredXYWHBoundingBox.from_top_left_xywh(bounding_box_factory(coordinates).to_top_left_xywh().normalize(image_width, image_height))
+    xywh_coordinates = convert_to_xywh(bounding_box_factory(coordinates), image_width, image_height)
 
     return [bbox[tlc.LABEL], *xywh_coordinates]
 

--- a/utils/loggers/tlc/settings.py
+++ b/utils/loggers/tlc/settings.py
@@ -193,6 +193,10 @@ class Settings:
         tlc_env_vars = {option.envvar for option in options.OPTION.__subclasses__() if option.envvar}
         unsupported_env_vars = unsupported_env_vars - tlc_env_vars
 
+        # Do not warn about TLC_ALIAS_* environment variables
+        tlc_alias_env_vars = {var for var in os.environ if var.startswith("TLC_ALIAS_")}
+        unsupported_env_vars = unsupported_env_vars - tlc_alias_env_vars
+
         # Output all environment variables if there are any unsupported ones
         if len(unsupported_env_vars) > 1:
             LOGGER.warning(

--- a/utils/loggers/tlc/utils.py
+++ b/utils/loggers/tlc/utils.py
@@ -310,21 +310,10 @@ def check_table_compatibility(table: tlc.Table) -> bool:
     assert tlc.BOUNDING_BOX_LIST in row_schema[tlc.BOUNDING_BOXES].values, "Bounding box column does not contain a bounding box list"
     assert tlc.SAMPLE_WEIGHT in row_schema, f"Table does not contain a sample weight column {tlc.SAMPLE_WEIGHT}"
     assert tlc.LABEL in row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values, f"Bounding box list does not contain a label {tlc.LABEL}"
-    assert tlc.X0 in row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values, f"Bounding box list does not contain a center x named {tlc.X0}"
-    assert tlc.Y0 in row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values, f"Bounding box list does not contain a center y named {tlc.Y0}"
-    assert tlc.X1 in row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values, f"Bounding box list does not contain width {tlc.X1}"
-    assert tlc.Y1 in row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values, f"Bounding box list does not contain height {tlc.Y1}"
 
-    X0 = row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values[tlc.X0]
-    Y0 = row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values[tlc.Y0]
-    X1 = row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values[tlc.X1]
-    Y1 = row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values[tlc.Y1]
-
-    assert X0.value.number_role == tlc.NUMBER_ROLE_BB_CENTER_X, f"{tlc.X0} has number role {X0.value.number_role}, expected {tlc.NUMBER_ROLE_BB_CENTER_X}"
-    assert Y0.value.number_role == tlc.NUMBER_ROLE_BB_CENTER_Y, f"{tlc.Y0} has number role {Y0.value.number_role}, expected {tlc.NUMBER_ROLE_BB_CENTER_Y}"
-    assert X1.value.number_role == tlc.NUMBER_ROLE_BB_SIZE_X, f"{tlc.X1} has number role {X1.value.number_role}, expected {tlc.NUMBER_ROLE_BB_SIZE_X}"
-    assert Y1.value.number_role == tlc.NUMBER_ROLE_BB_SIZE_Y, f"{tlc.Y1} has number role {Y1.value.number_role}, expected {tlc.NUMBER_ROLE_BB_SIZE_Y}"
-
+    for coordinate in [tlc.X0, tlc.Y0, tlc.X1, tlc.Y1]:
+        assert coordinate in row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values, f"Bounding box list does not contain a {coordinate}"
+    
     return True
 
 


### PR DESCRIPTION
Also fixes the case where the integration would warn about unsupported environment variables starting with `TLC_ALIAS_`, when this is a supported feature in the 3lc package.