### PR TITLE
Migrate 3LC integration to 3lc 3.0

### DIFF
--- a/.github/workflows/3lc-ci.yml
+++ b/.github/workflows/3lc-ci.yml
@@ -30,13 +30,11 @@ jobs:
           cache-dependency-glob: requirements*.txt
       - name: ruff check
         run: uvx ruff check
-      # `ruff format --check` and `ty check` will be added in a follow-up PR
-      # alongside the integration code refactor. ty surfaces ~10 pre-existing
-      # return-type and overload issues in the current tlc code; fixing them
-      # belongs with the catch-up work, not with scaffolding.
+      - name: ruff format
+        run: uvx ruff format --check utils/loggers/tlc/ tests/
 
   tests:
-    name: pytest
+    name: ty & pytest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -46,10 +44,24 @@ jobs:
           # This repo has no uv.lock (not a uv project), which is the
           # default cache-key glob and a hard error when absent.
           cache-dependency-glob: requirements*.txt
+      - name: Install dependencies
+        # torch is installed first from the CPU index so the CUDA wheels
+        # (several GB) are never pulled onto the runner; the requirements
+        # installs then see torch as already satisfied. torch<2.6 because
+        # torch 2.6 flipped torch.load to weights_only=True, which upstream
+        # YOLOv5 fixed after this fork's merge-base — drop the bound after
+        # the next upstream sync.
+        run: |
+          uv venv
+          uv pip install "torch<2.6" "torchvision<0.21" --index-url https://download.pytorch.org/whl/cpu
+          uv pip install -r requirements.txt -r requirements-dev.txt --index-strategy unsafe-best-match
+      - name: ty check
+        run: .venv/bin/ty check
       - name: pytest
-        # Once real integration tests land in a follow-up PR, install 3lc here.
         # `-o addopts=` overrides upstream's broken [tool.pytest] block in
         # pyproject.toml (it uses a string instead of a list, which newer
         # pytest rejects). We don't touch pyproject.toml to fix it because
         # that file is upstream-owned.
-        run: uvx pytest -o "addopts=" tests/
+        run: .venv/bin/pytest -o "addopts=" tests/
+        env:
+          TLC_API_KEY: ${{ secrets.TLC_API_KEY }}

--- a/.github/workflows/3lc-lint.yml
+++ b/.github/workflows/3lc-lint.yml
@@ -35,12 +35,14 @@ jobs:
         # environment, so type-checking needs the full requirements. torch is
         # installed first from the CPU index so the CUDA wheels (several GB)
         # are never pulled onto the runner; the requirements installs then see
-        # torch as already satisfied. torch<2.6 because torch 2.6 flipped
-        # torch.load to weights_only=True, which upstream YOLOv5 fixed after
-        # this fork's merge-base — drop the bound after the next upstream sync.
+        # torch as already satisfied.
+        #
+        # The torch<2.6 / numpy<2 pins mirror 3lc-tests.yml (upstream-YOLOv5
+        # lag; drop after the next upstream sync) and keep the type-checked
+        # environment identical to the tested one.
         run: |
           uv venv
           uv pip install "torch<2.6" "torchvision<0.21" --index-url https://download.pytorch.org/whl/cpu
-          uv pip install -r requirements.txt -r requirements-dev.txt --index-strategy unsafe-best-match
+          uv pip install -r requirements.txt -r requirements-dev.txt "numpy<2" --index-strategy unsafe-best-match
       - name: ty check
         run: .venv/bin/ty check

--- a/.github/workflows/3lc-lint.yml
+++ b/.github/workflows/3lc-lint.yml
@@ -1,0 +1,46 @@
+# 3LC integration lint/format/type checks for the 3lc-ai/yolov5 fork.
+#
+# Owned by the 3LC integration in utils/loggers/tlc/. Runs on this fork's
+# branches (develop, tlc_*) only; upstream's ci-testing.yml continues to fire
+# on master. Tests live in 3lc-tests.yml.
+
+name: 3LC lint
+
+on:
+  pull_request:
+    branches: [develop, "tlc_*"]
+  push:
+    branches: [develop, "tlc_*"]
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: ruff & ty
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          # This repo has no uv.lock (not a uv project), which is the
+          # default cache-key glob and a hard error when absent.
+          cache-dependency-glob: requirements*.txt
+      # The ruff steps need no dependencies — run them first for fast failures.
+      - name: ruff check
+        run: uvx ruff check
+      - name: ruff format
+        run: uvx ruff format --check utils/loggers/tlc/ tests/
+      - name: Install dependencies
+        # ty resolves third-party imports (tlc, torch, ...) from the installed
+        # environment, so type-checking needs the full requirements. torch is
+        # installed first from the CPU index so the CUDA wheels (several GB)
+        # are never pulled onto the runner; the requirements installs then see
+        # torch as already satisfied. torch<2.6 because torch 2.6 flipped
+        # torch.load to weights_only=True, which upstream YOLOv5 fixed after
+        # this fork's merge-base — drop the bound after the next upstream sync.
+        run: |
+          uv venv
+          uv pip install "torch<2.6" "torchvision<0.21" --index-url https://download.pytorch.org/whl/cpu
+          uv pip install -r requirements.txt -r requirements-dev.txt --index-strategy unsafe-best-match
+      - name: ty check
+        run: .venv/bin/ty check

--- a/.github/workflows/3lc-tests.yml
+++ b/.github/workflows/3lc-tests.yml
@@ -32,14 +32,16 @@ jobs:
       - name: Install dependencies
         # torch is installed first from the CPU index so the CUDA wheels
         # (several GB) are never pulled onto the runner; the requirements
-        # installs then see torch as already satisfied. torch<2.6 because
-        # torch 2.6 flipped torch.load to weights_only=True, which upstream
-        # YOLOv5 fixed after this fork's merge-base — drop the bound after
-        # the next upstream sync.
+        # installs then see torch as already satisfied.
+        #
+        # Pins that paper over upstream-YOLOv5 lag — drop both after the next
+        # upstream sync: torch<2.6 (torch 2.6 flipped torch.load to
+        # weights_only=True) and numpy<2 (numpy 2.0 removed np.trapz, still
+        # used by utils/metrics.py at this fork's merge-base).
         run: |
           uv venv
           uv pip install "torch<2.6" "torchvision<0.21" --index-url https://download.pytorch.org/whl/cpu
-          uv pip install -r requirements.txt -r requirements-dev.txt --index-strategy unsafe-best-match
+          uv pip install -r requirements.txt -r requirements-dev.txt "numpy<2" --index-strategy unsafe-best-match
       - name: pytest
         # `-o addopts=` overrides upstream's broken [tool.pytest] block in
         # pyproject.toml (it uses a string instead of a list, which newer

--- a/.github/workflows/3lc-tests.yml
+++ b/.github/workflows/3lc-tests.yml
@@ -1,13 +1,14 @@
-# 3LC integration CI for the 3lc-ai/yolov5 fork.
+# 3LC integration tests for the 3lc-ai/yolov5 fork.
 #
 # Owned by the 3LC integration in utils/loggers/tlc/. Runs on this fork's
 # branches (develop, tlc_*) only; upstream's ci-testing.yml continues to fire
-# on master.
+# on master. Lint/format/type checks live in 3lc-lint.yml.
 #
-# CI uses `uv` for fast dependency installs and `uvx` for one-shot tool runs.
-# Users still install with plain `pip install -r requirements.txt` per upstream.
+# The end-to-end tests train and collect metrics on coco128 for real, so the
+# `TLC_API_KEY` repository secret must be set to a valid 3LC API key — they
+# fail (not skip) without one.
 
-name: 3LC integration CI
+name: 3LC tests
 
 on:
   pull_request:
@@ -17,24 +18,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint:
-    name: ruff
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
-        with:
-          enable-cache: true
-          # This repo has no uv.lock (not a uv project), which is the
-          # default cache-key glob and a hard error when absent.
-          cache-dependency-glob: requirements*.txt
-      - name: ruff check
-        run: uvx ruff check
-      - name: ruff format
-        run: uvx ruff format --check utils/loggers/tlc/ tests/
-
   tests:
-    name: ty & pytest
+    name: pytest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -55,8 +40,6 @@ jobs:
           uv venv
           uv pip install "torch<2.6" "torchvision<0.21" --index-url https://download.pytorch.org/whl/cpu
           uv pip install -r requirements.txt -r requirements-dev.txt --index-strategy unsafe-best-match
-      - name: ty check
-        run: .venv/bin/ty check
       - name: pytest
         # `-o addopts=` overrides upstream's broken [tool.pytest] block in
         # pyproject.toml (it uses a string instead of a list, which newer

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,12 @@
+"""Import test for the 3LC integration.
+
+Importing the integration package runs the 3lc / 3lc-ultralytics version guard and
+imports every integration module, so this catches API breaks against the installed
+3lc packages without needing an API key or any data.
+"""
+
+
+def test_import_integration() -> None:
+    import utils.loggers.tlc
+
+    assert utils.loggers.tlc.create_dataloader is not None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,81 @@
+"""End-to-end tests for the 3LC YOLOv5 integration.
+
+These tests run the real train.py / val.py entry points on coco128 with the 3LC
+integration active. They require a valid `TLC_API_KEY` (provided as a repository
+secret in CI) and are skipped when it is not set.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("TLC_API_KEY"),
+    reason="End-to-end 3LC tests require a valid TLC_API_KEY",
+)
+
+
+@pytest.fixture(scope="session")
+def tlc_project_root(tmp_path_factory: pytest.TempPathFactory) -> str:
+    """An isolated 3LC project root, so test tables and runs don't pollute the local one."""
+    return str(tmp_path_factory.mktemp("3lc_project_root"))
+
+
+def run_script(args: list[str], tlc_project_root: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ | {"TLC_PROJECT_ROOT_URL": tlc_project_root}
+    return subprocess.run([sys.executable, *args], cwd=ROOT, env=env, capture_output=True, text=True, timeout=1800)
+
+
+def assert_succeeded(result: subprocess.CompletedProcess[str]) -> None:
+    assert result.returncode == 0, (
+        f"{' '.join(result.args[1:3])} failed\nstdout: {result.stdout[-5000:]}\nstderr: {result.stderr[-5000:]}"
+    )
+
+
+def test_train_one_epoch(tlc_project_root: str, tmp_path: Path) -> None:
+    """Train for one epoch on coco128, creating 3LC tables and collecting metrics after training."""
+    result = run_script(
+        [
+            "train.py",
+            "--data",
+            "coco128.yaml",
+            "--weights",
+            "yolov5n.pt",
+            "--img",
+            "320",
+            "--batch-size",
+            "16",
+            "--epochs",
+            "1",
+            "--project",
+            str(tmp_path / "runs"),
+        ],
+        tlc_project_root,
+    )
+    assert_succeeded(result)
+
+
+def test_collect_metrics(tlc_project_root: str) -> None:
+    """Collect metrics on the train and val splits of coco128 without training."""
+    result = run_script(
+        [
+            "val.py",
+            "--task",
+            "collect",
+            "--data",
+            "coco128.yaml",
+            "--weights",
+            "yolov5n.pt",
+            "--img",
+            "320",
+        ],
+        tlc_project_root,
+    )
+    assert_succeeded(result)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,8 +1,9 @@
 """End-to-end tests for the 3LC YOLOv5 integration.
 
 These tests run the real train.py / val.py entry points on coco128 with the 3LC
-integration active. They require a valid `TLC_API_KEY` (provided as a repository
-secret in CI) and are skipped when it is not set.
+integration active. They require a valid 3LC API key — the `TLC_API_KEY`
+repository secret in CI, or the local 3LC configuration when run locally — and
+fail without one.
 """
 
 from __future__ import annotations
@@ -15,11 +16,6 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
-
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("TLC_API_KEY"),
-    reason="End-to-end 3LC tests require a valid TLC_API_KEY",
-)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_scaffolding.py
+++ b/tests/test_scaffolding.py
@@ -1,9 +1,0 @@
-"""Placeholder test to verify the pytest harness runs in CI.
-
-Real tests for the 3LC integration will be added in follow-up PRs as the
-integration is brought up to the latest 3lc release.
-"""
-
-
-def test_pytest_runs() -> None:
-    assert 1 + 1 == 2

--- a/utils/loggers/tlc/DEVELOPMENT.md
+++ b/utils/loggers/tlc/DEVELOPMENT.md
@@ -12,6 +12,13 @@ documentation lives in [README.md](README.md).
 | `feature/<owner>/<topic>` | Short-lived feature branches off `develop`. |
 | `tlc_<version>` | Historical, frozen branches. Read-only. |
 
+## Releases
+
+There are none. The fork is not packaged, versioned or tagged — the HEAD of
+`develop` is what users clone. This means every commit on `develop` must be
+self-consistent: documentation and install instructions may only promise what
+the code on that same commit delivers.
+
 ## Local development
 
 Install the dev dependencies on top of upstream's requirements. `3lc` 3.0+ is
@@ -26,18 +33,50 @@ pip install -r requirements.txt -r requirements-dev.txt
 uv pip install -r requirements.txt -r requirements-dev.txt --index-strategy unsafe-best-match
 ```
 
-Lint, type-check and test (scope is defined in `ruff.toml` / `ty.toml`):
+Lint, format, type-check and test (scope is defined in `ruff.toml` / `ty.toml`):
 
 ```bash
 ruff check
+ruff format --check utils/loggers/tlc/ tests/
 ty check
 pytest -o "addopts=" tests/  # -o sidesteps upstream's broken [tool.pytest] block in pyproject.toml
 ```
 
+The end-to-end tests in `tests/` are skipped unless `TLC_API_KEY` is set to a
+valid 3LC API key.
+
 ## CI
 
-`.github/workflows/3lc-ci.yml` runs `ruff check` and `pytest` on PRs and
-pushes to `develop`. `ty check` and `ruff format --check` are configured and
-runnable locally, but not yet gated in CI — they will be turned on when the
-3.0 migration lands. Upstream's `ci-testing.yml` continues to fire on
-`master` and is not touched here.
+`.github/workflows/3lc-ci.yml` runs on PRs and pushes to `develop`:
+
+- **lint**: `ruff check` and `ruff format --check` (no dependencies needed).
+- **tests**: installs the full requirements (including `3lc` and
+  `3lc-ultralytics`), then runs `ty check` and `pytest`. The end-to-end tests
+  need the `TLC_API_KEY` repository secret.
+
+Upstream's `ci-testing.yml` continues to fire on `master` and is not touched
+here.
+
+## Upstream sync (quarterly)
+
+Merge upstream into `develop` roughly once a quarter:
+
+```bash
+git remote add ultralytics https://github.com/ultralytics/yolov5.git  # once
+git fetch ultralytics
+git checkout develop
+git checkout -b chore/<owner>/upstream-sync
+git merge ultralytics/master
+```
+
+Notes:
+
+- Fork-owned files (`utils/loggers/tlc/**`, `tests/**`, `ruff.toml`,
+  `ty.toml`, `requirements-dev.txt`, `.github/workflows/3lc-ci.yml`) are never
+  touched by upstream, so conflicts are confined to the few upstream files the
+  integration hooks into: `train.py`, `val.py`, `utils/loggers/__init__.py`,
+  `models/yolo.py`, `utils/general.py` and `README.md`.
+- On conflicts, take upstream's version and re-apply the integration hook
+  points.
+- PR the sync branch into `develop` so CI validates the merge, then
+  fast-forward the `master` mirror to `ultralytics/master`.

--- a/utils/loggers/tlc/DEVELOPMENT.md
+++ b/utils/loggers/tlc/DEVELOPMENT.md
@@ -42,17 +42,17 @@ ty check
 pytest -o "addopts=" tests/  # -o sidesteps upstream's broken [tool.pytest] block in pyproject.toml
 ```
 
-The end-to-end tests in `tests/` are skipped unless `TLC_API_KEY` is set to a
-valid 3LC API key.
+The end-to-end tests in `tests/` require a valid 3LC API key — locally the
+one from your 3LC configuration is used; in CI the `TLC_API_KEY` repository
+secret provides it. They fail (not skip) without one.
 
 ## CI
 
-`.github/workflows/3lc-ci.yml` runs on PRs and pushes to `develop`:
+Two workflows run on PRs and pushes to `develop`:
 
-- **lint**: `ruff check` and `ruff format --check` (no dependencies needed).
-- **tests**: installs the full requirements (including `3lc` and
-  `3lc-ultralytics`), then runs `ty check` and `pytest`. The end-to-end tests
-  need the `TLC_API_KEY` repository secret.
+- **`3lc-lint.yml`**: `ruff check`, `ruff format --check` and `ty check`
+  (ty needs the full requirements installed to resolve third-party imports).
+- **`3lc-tests.yml`**: installs the full requirements and runs `pytest`.
 
 Upstream's `ci-testing.yml` continues to fire on `master` and is not touched
 here.

--- a/utils/loggers/tlc/README.md
+++ b/utils/loggers/tlc/README.md
@@ -21,10 +21,16 @@ This document outlines how to use the 3LC integration available for YOLOv5.
 
 ## Getting Started
 
-The integration is automatically enabled if the `3lc` package is installed in your environment. It can be installed with 
+Clone the `develop` branch of this fork and install the YOLOv5 requirements along with the 3LC packages. The integration requires both `3lc` and `3lc-ultralytics`, which are published on 3LC's public package index, not on PyPI, so an extra index URL is needed:
+
+```bash
+git clone -b develop https://github.com/3lc-ai/yolov5.git
+cd yolov5
+pip install -r requirements.txt "torch<2.6"  # torch<2.6 until the next upstream sync (torch 2.6 changed torch.load defaults)
+pip install 3lc 3lc-ultralytics --extra-index-url https://pypi.3lc.ai/public/repositories/releases-public
 ```
-pip install 3lc
-```
+
+The integration is automatically enabled when `3lc` is installed in your environment.
 
 ### First Time
 

--- a/utils/loggers/tlc/README.md
+++ b/utils/loggers/tlc/README.md
@@ -26,7 +26,7 @@ Clone the `develop` branch of this fork and install the YOLOv5 requirements alon
 ```bash
 git clone -b develop https://github.com/3lc-ai/yolov5.git
 cd yolov5
-pip install -r requirements.txt "torch<2.6"  # torch<2.6 until the next upstream sync (torch 2.6 changed torch.load defaults)
+pip install -r requirements.txt "torch<2.6" "numpy<2"  # torch/numpy bounds needed until the next upstream sync
 pip install 3lc 3lc-ultralytics --extra-index-url https://pypi.3lc.ai/public/repositories/releases-public
 ```
 

--- a/utils/loggers/tlc/base.py
+++ b/utils/loggers/tlc/base.py
@@ -1,24 +1,25 @@
 # YOLOv5 🚀 by Ultralytics, AGPL-3.0 license
 """Base class for 3LC loggers used for training and validation."""
+
 from __future__ import annotations
+
+from typing import Any
 
 import numpy as np
 import tlc
 import torch
+from tlc_ultralytics.detect.utils import construct_bbox_struct
+from tlc_ultralytics.utils import image_embeddings_schema, training_phase_schema
 
 from models.common import DetectMultiBackend
 from utils.general import scale_boxes, xywh2xyxy, xyxy2xywhn
 from utils.loggers.tlc import yolo
 from utils.loggers.tlc.constants import TRAINING_PHASE
 from utils.loggers.tlc.utils import (
-    construct_bbox_struct,
     get_names_from_yolo_table,
-    training_phase_schema,
-    yolo_image_embeddings_schema,
     yolo_loss_schemas,
     yolo_predicted_bounding_box_schema,
 )
-from utils.metrics import box_iou
 
 
 class BaseTLCCallback:
@@ -36,7 +37,7 @@ class BaseTLCCallback:
         :return: Metrics schema
         """
         schema = {
-            tlc.PREDICTED_BOUNDING_BOXES: yolo_predicted_bounding_box_schema(self.data_dict["names"]),
+            tlc.constants.PREDICTED_BOUNDING_BOXES: yolo_predicted_bounding_box_schema(self.data_dict["names"]),
             TRAINING_PHASE: training_phase_schema(),
         }
 
@@ -44,7 +45,7 @@ class BaseTLCCallback:
             schema.update(yolo_loss_schemas(num_classes=self.data_dict["nc"]))
 
         if self._settings.image_embeddings_dim != 0:
-            schema.update(yolo_image_embeddings_schema(activation_size=self.activation_size()))
+            schema["embeddings"] = image_embeddings_schema(activation_size=self.activation_size())
 
         return schema
 
@@ -116,7 +117,7 @@ class BaseTLCCallback:
             image = images[si]
             labels = targets[targets[:, 0] == si, 1:]
             shape = shapes[si]
-            predn, labelsn = self.preprocess_prediction(image, labels, shape, pred)
+            predn, _ = self.preprocess_prediction(image, labels, shape, pred)
 
             # Process the predictions
             detections = predn[predn[:, 4] > self._settings.conf_thres]
@@ -124,20 +125,6 @@ class BaseTLCCallback:
             detections = detections[
                 detections[:, 4].argsort(descending=True)[: self._settings.max_det]
             ]  # sort by confidence and remove excess boxes
-
-            if labelsn is not None:
-                # Compute IoU
-                iou = box_iou(labelsn[:, 1:], detections[:, :4])
-
-                pred_classes = detections[:, 5]
-                target_classes = labelsn[:, 0]
-
-                mask = target_classes[:, None] == pred_classes
-                iou = iou * mask
-
-                ious = iou.cpu().numpy().max(axis=0)
-            else:
-                ious = [0.0] * len(detections)
 
             # Convert back to xywhn for saving 3LC box predictions
             pred_xywhn = detections.clone()
@@ -147,10 +134,8 @@ class BaseTLCCallback:
 
             # Save the boxes as dicts
             annotations = [
-                dict(
-                    category_id=int(prediction[5]), score=float(prediction[4]), bbox=prediction[:4], iou=float(ious[i])
-                )
-                for i, prediction in enumerate(pred_xywhn)
+                dict(category_id=int(prediction[5]), score=float(prediction[4]), bbox=prediction[:4])
+                for prediction in pred_xywhn
             ]
             predictions.append(annotations)
 
@@ -166,25 +151,25 @@ class BaseTLCCallback:
         ]
 
         # Always collect example ids and predicted bounding boxes
-        metrics_batch = {
-            tlc.EXAMPLE_ID: example_ids,
-            tlc.PREDICTED_BOUNDING_BOXES: predicted_bounding_boxes,
+        metrics_batch: dict[str, Any] = {
+            tlc.constants.EXAMPLE_ID: example_ids,
+            tlc.constants.PREDICTED_BOUNDING_BOXES: predicted_bounding_boxes,
         }
 
         # Collect epoch only when training
         if epoch is not None:
-            metrics_batch[tlc.EPOCH] = [epoch] * batch_size
+            metrics_batch[tlc.constants.EPOCH] = [epoch] * batch_size
             metrics_batch[TRAINING_PHASE] = [1 if self._reached_final_validation else 0] * batch_size
 
         # Embeddings
         if self._settings.image_embeddings_dim != 0:
-            assert len(
-                yolo.global_activations
-            ), f"Should only have one set of embeddings per batch, was {len(yolo.global_activations)}"
+            assert len(yolo.global_activations), (
+                f"Should only have one set of embeddings per batch, was {len(yolo.global_activations)}"
+            )
             metrics_batch["embeddings"] = yolo.global_activations.pop()
-            assert (
-                metrics_batch["embeddings"].shape[1] == self._activation_size
-            ), f"Mismatch in embedding size, expected {self._activation_size} got {metrics_batch['embeddings'].shape[1]}"
+            assert metrics_batch["embeddings"].shape[1] == self._activation_size, (
+                f"Mismatch in embedding size, expected {self._activation_size} got {metrics_batch['embeddings'].shape[1]}"
+            )
 
         # Loss
         if self._settings.collect_loss:
@@ -205,18 +190,8 @@ class BaseTLCCallback:
         """
         self.run.add_input_table(input_table)
 
-        # Flush the metrics writer and update the Run with the metrics-infos.
+        # Flush the metrics writer. As of 3lc 3.0, finalize() also updates the Run with the written metrics infos.
         self.metrics_writer.finalize()
-        metrics_infos = self.metrics_writer.get_written_metrics_infos()
-
-        self.run.update_metrics(metrics_infos)
-
-        # Remove metrics tables from 3lc object cache
-        for metrics_info in metrics_infos:
-            tlc.ObjectRegistry._delete_object_from_caches(
-                tlc.Url(metrics_info["url"]).to_absolute(self.run.url)
-            )
-
 
     def compute_loss(self, train_out: torch.Tensor, targets: torch.Tensor) -> dict[str, torch.Tensor]:
         """
@@ -239,8 +214,8 @@ class BaseTLCCallback:
         return metrics
 
     def preprocess_prediction(
-        self, image: torch.Tensor, labels: torch.Tensor, shape: list[list[int], list[list[int]]], pred: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+        self, image: torch.Tensor, labels: torch.Tensor, shape: Any, pred: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """
         Preprocesses the prediction for saving, mapping them back to native space.
 
@@ -298,20 +273,18 @@ class BaseTLCCallback:
         :param confusion_matrix: Confusion matrix
         """
         names = get_names_from_yolo_table(self.table)
-        column_schemas = tlc.SampleType.from_structure(
-            {
-                "Split": tlc.CategoricalLabel(name="Split", classes=["train", "val"]),
-                "Class": tlc.CategoricalLabel(name="Class", classes=list(names.values())),
-                "Targets": tlc.Int,
-                "TPs": tlc.Int,
-                "FPs": tlc.Int,
-                "Precision": tlc.Float,
-                "Recall": tlc.Float,
-                "F1": tlc.Float,
-                "AP": tlc.Float,
-                "AP50": tlc.Float,
-            }
-        ).schema.values
+        column_schemas = {
+            "Split": tlc.schemas.CategoricalLabelSchema(classes=["train", "val"], display_name="Split"),
+            "Class": tlc.schemas.CategoricalLabelSchema(classes=list(names.values()), display_name="Class"),
+            "Targets": tlc.schemas.Int32Schema(),
+            "TPs": tlc.schemas.Int32Schema(),
+            "FPs": tlc.schemas.Int32Schema(),
+            "Precision": tlc.schemas.Float32Schema(),
+            "Recall": tlc.schemas.Float32Schema(),
+            "F1": tlc.schemas.Float32Schema(),
+            "AP": tlc.schemas.Float32Schema(),
+            "AP50": tlc.schemas.Float32Schema(),
+        }
 
         metrics = {
             "Split": [int(self.split == "train")] * len(ap_class),
@@ -326,8 +299,4 @@ class BaseTLCCallback:
             "AP50": ap50,
         }
 
-        self.run.add_metrics_data(
-            metrics=metrics,
-            override_column_schemas=column_schemas,
-            table_writer_base_name=f"{self.split}_per_class_metrics",
-        )
+        self.run.add_metrics(metrics, schema=column_schemas)

--- a/utils/loggers/tlc/collect.py
+++ b/utils/loggers/tlc/collect.py
@@ -10,6 +10,7 @@ Available environment variables to configure collection:
     TLC_COLLECT_LOSS: Whether to collect loss. Default: false.
     TLC_COLLECTION_SPLITS: Comma-separated list of splits to collect metrics on. Default: train,val.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -34,8 +35,6 @@ ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 from typing import Any
 
-from tlc.client.utils import batched_iterator
-
 from models.common import DetectMultiBackend
 from models.yolo import DetectionModel
 from utils.callbacks import Callbacks
@@ -44,7 +43,12 @@ from utils.loggers.tlc.base import BaseTLCCallback
 from utils.loggers.tlc.constants import TLC_COLLECT_PATH, TLC_COLORSTR
 from utils.loggers.tlc.dataloaders import create_dataloader
 from utils.loggers.tlc.settings import Settings
-from utils.loggers.tlc.utils import get_names_from_yolo_table, tlc_check_dataset, verify_model_table_compatible
+from utils.loggers.tlc.utils import (
+    batched_iterator,
+    get_names_from_yolo_table,
+    tlc_check_dataset,
+    verify_model_table_compatible,
+)
 from utils.loggers.tlc.yolo import TLCDetectionModel
 from utils.loss import ComputeLoss
 from utils.torch_utils import select_device
@@ -70,9 +74,9 @@ def collect_metrics(opt: argparse.Namespace) -> None:
     model, half, batch_size, imgsz = load_model(opt, settings)
 
     # Sanity checks
-    assert all(
-        split in tables for split in settings.collection_splits
-    ), f"Not all splits {settings.collection_splits} are in the dataset {tables}"
+    assert all(split in tables for split in settings.collection_splits), (
+        f"Not all splits {settings.collection_splits} are in the dataset {tables}"
+    )
     project_name = tables[settings.collection_splits[0]].project_name
 
     run = tlc.init(project_name=project_name)
@@ -165,9 +169,9 @@ def load_model(opt: argparse.Namespace, settings: Settings) -> tuple[DetectMulti
 
     stride, pt, jit, engine = model.stride, model.pt, model.jit, model.engine
     imgsz = check_img_size(opt.imgsz, s=stride)  # check image size
-    half = model.fp16  # FP16 supported on limited backends with CUDA
+    half = bool(model.fp16)  # FP16 supported on limited backends with CUDA
     if engine:
-        batch_size = model.batch_size
+        batch_size = int(model.batch_size)
     else:
         device = model.device
         if not (pt or jit):
@@ -211,7 +215,7 @@ class TLCCollectionCallback(BaseTLCCallback):
         self.metrics_writer = tlc.MetricsTableWriter(
             run_url=self.run.url,
             foreign_table_url=self.table.url,
-            column_schemas=self.metrics_schema,
+            schema=self.metrics_schema,
         )
 
         self.example_ids_for_batch = list(batched_iterator(range(len(self.example_ids)), batch_size=batch_size))

--- a/utils/loggers/tlc/constants.py
+++ b/utils/loggers/tlc/constants.py
@@ -9,7 +9,8 @@ TLC_COLORSTR = colorstr("3LC: ")
 TLC_TRAIN_PATH = "3lc_train"
 TLC_VAL_PATH = "3lc_val"
 TLC_COLLECT_PATH = "3lc_collect"
-TLC_VERSION_REQUIRED = "2.7.1"
+TLC_VERSION_REQUIRED = "3.0.0"
+TLC_ULTRALYTICS_VERSION_REQUIRED = "0.3.0"
 
 # Column names
 TRAINING_PHASE = "Training Phase"

--- a/utils/loggers/tlc/dataloaders.py
+++ b/utils/loggers/tlc/dataloaders.py
@@ -2,10 +2,10 @@
 """
 Dataloaders and dataset utils - 3LC integration
 """
+
 from __future__ import annotations
 
 import os
-from collections.abc import Callable
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from typing import Any
@@ -14,8 +14,8 @@ import numpy as np
 import tlc
 import torch
 from PIL import Image, ImageOps
-from tlc.core.builtins.types.bounding_box import CenteredXYWHBoundingBox
-from tlc.core.utils.progress import track
+from tlc.data_types import BoundingBoxes2D
+from tlc.helpers import AnnotationHelper, AnnotationType
 from torch.utils.data import DataLoader, distributed
 from tqdm import tqdm
 
@@ -31,34 +31,35 @@ LOCAL_RANK = int(os.getenv("LOCAL_RANK", -1))  # https://pytorch.org/docs/stable
 RANK = int(os.getenv("RANK", -1))
 PIN_MEMORY = str(os.getenv("PIN_MEMORY", True)).lower() == "true"  # global pin_memory for dataloaders
 
-def convert_to_xywh(bbox: tlc.BoundingBox, image_width: int, image_height: int) -> CenteredXYWHBoundingBox:
-    """Convert a bounding box to xc, yc, w, h, normalized to [0, 1].
 
-    :param bbox: The 3LC bounding box to convert.
-    :param image_width: The width of the image.
-    :param image_height: The height of the image.
-    :return: The bounding box converted to xc, yc, w, h.
+def tlc_table_row_to_yolo_label(
+    row: dict[str, Any], bb_column: str, bb_schema: tlc.Schema | None
+) -> tuple[np.ndarray, tuple[int, int]]:
+    """Convert the bounding boxes in a 3LC table row to a YOLO label array.
+
+    Handles both legacy (`bb_list` dict) and 3.0 (`BoundingBoxes2D`) stored formats.
+
+    :param row: The table row.
+    :param bb_column: The name of the bounding box column.
+    :param bb_schema: The schema of the bounding box column for legacy tables, None for 3.0 tables.
+    :return: A (labels, (width, height)) tuple, where labels is an Nx5 array of
+        [class, xc, yc, w, h] rows with coordinates normalized to [0, 1].
     """
-    if isinstance(bbox, CenteredXYWHBoundingBox) and bbox.normalized:
-        return bbox
-    else:
-        return CenteredXYWHBoundingBox.from_top_left_xywh(bbox.to_top_left_xywh().normalize(image_width, image_height))
+    raw = row[bb_column]
+    bbs = BoundingBoxes2D.from_legacy_row(raw, bb_schema) if bb_schema is not None else BoundingBoxes2D.from_row(raw)
 
+    image_width = int(bbs.x_max - (bbs.x_min or 0))
+    image_height = int(bbs.y_max - (bbs.y_min or 0))
 
-def unpack_box(bbox: dict[str, Any], bounding_box_factory: Callable[..., tlc.BoundingBox], image_width: int, image_height: int) -> list[int | float]:
-    coordinates = [bbox[tlc.X0], bbox[tlc.Y0], bbox[tlc.X1], bbox[tlc.Y1]]
+    if bbs.num_instances == 0 or bbs.labels is None:
+        return np.zeros((0, 5), dtype=np.float32), (image_width, image_height)
 
-    xywh_coordinates = convert_to_xywh(bounding_box_factory(coordinates), image_width, image_height)
+    cxywh = bbs.bounding_boxes_cxywh / np.array(
+        [image_width, image_height, image_width, image_height], dtype=np.float32
+    )
+    labels = np.asarray(bbs.labels, dtype=np.float32).reshape(-1, 1)
 
-    return [bbox[tlc.LABEL], *xywh_coordinates]
-
-
-def tlc_table_row_to_yolo_label(row: dict[str, Any], bounding_box_factory: Callable[..., tlc.BoundingBox], image_width: int, image_height: int) -> np.ndarray:
-    unpacked = [unpack_box(box, bounding_box_factory, image_width, image_height) for box in row[tlc.BOUNDING_BOXES][tlc.BOUNDING_BOX_LIST]]
-    arr = np.array(unpacked, ndmin=2, dtype=np.float32)
-    if len(unpacked) == 0:
-        arr = arr.reshape(0, 5)
-    return arr
+    return np.concatenate([labels, cxywh.astype(np.float32)], axis=1), (image_width, image_height)
 
 
 def create_dataloader(
@@ -80,7 +81,7 @@ def create_dataloader(
     shuffle: bool = False,
     seed: int = 0,
 ) -> tuple[DataLoader, LoadImagesAndLabels]:
-    """ Create dataloader in the 3LC integration. In addition to the standard behavior, this function also
+    """Create dataloader in the 3LC integration. In addition to the standard behavior, this function also
     handles 3LC-specific arguments (zero weight exclusion and sampling weights), logging and reading of
     other properties required by the 3LC integration logger.
 
@@ -222,7 +223,7 @@ class TLCLoadImagesAndLabels(LoadImagesAndLabels):
         self.tlc_name = table.dataset_name
         self.tlc_table_url = table.url.to_str()
 
-        self.sampling_weights = []
+        sampling_weights = []
         self.im_files = []
         self.shapes = []
         self.labels = []
@@ -232,19 +233,26 @@ class TLCLoadImagesAndLabels(LoadImagesAndLabels):
 
         pbar = iter(table.table_rows)
         if RANK in {-1, 0}:
-            pbar = track(pbar, description=f"Loading data from 3LC Table {table.dataset_name}/{table.url.name}", total=len(table))
+            pbar = tqdm(
+                pbar,
+                desc=f"Loading data from 3LC Table {table.dataset_name}/{table.url.name}",
+                total=len(table),
+                bar_format=TQDM_BAR_FORMAT,
+            )
 
         # Keep track of which example ids are in use (map from index in the yolo dataset to example id)
         self.example_ids = []
         num_ignored = 0
 
-        try:
-            bounding_box_factory = tlc.BoundingBox.from_schema(table.rows_schema.values[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST])
-        except Exception as e:
-            raise ValueError(f"Error inferring bounding box format for {table.dataset_name}.") from e
+        annotation = AnnotationHelper.find(table, type=AnnotationType.BOUNDING_BOXES)
+        if annotation is None:
+            raise ValueError(f"Error inferring bounding box format for {table.dataset_name}.")
+        bb_column = annotation.name
+        is_legacy = annotation.type is AnnotationType.LEGACY_BOUNDING_BOXES
+        bb_schema = table.rows_schema.values[bb_column] if is_legacy else None
 
         for example_id, row in enumerate(pbar):
-            im_file = tlc.Url(row[tlc.IMAGE]).to_absolute().to_str()
+            im_file = tlc.Url(row[tlc.constants.IMAGE]).to_absolute().to_str()
 
             # Fix fixable and discard corrupt images
             fixed, corrupt, msg = fix_image(im_file)
@@ -254,22 +262,23 @@ class TLCLoadImagesAndLabels(LoadImagesAndLabels):
             num_corrupt += int(corrupt)
 
             # Ignore zero weight images if tlc_exclude_zero_weight is set
-            ignore = tlc_exclude_zero_weight and row[tlc.SAMPLE_WEIGHT] == 0.0
+            ignore = tlc_exclude_zero_weight and row[tlc.constants.SAMPLE_WEIGHT] == 0.0
             num_ignored += int(ignore)
 
             discard = corrupt or ignore
 
             if not discard:
-                self.sampling_weights.append(row[tlc.SAMPLE_WEIGHT])
+                labels, shape = tlc_table_row_to_yolo_label(row, bb_column, bb_schema)
+                sampling_weights.append(row[tlc.constants.SAMPLE_WEIGHT])
                 self.im_files.append(str(Path(im_file)))  # Ensure path is os.sep-delimited
-                self.shapes.append((row[tlc.WIDTH], row[tlc.HEIGHT]))
-                self.labels.append(tlc_table_row_to_yolo_label(row, bounding_box_factory, row[tlc.WIDTH], row[tlc.HEIGHT]))
+                self.shapes.append(shape)
+                self.labels.append(labels)
                 self.example_ids.append(example_id)
 
         self.shapes = np.array(self.shapes)
 
-        self.sampling_weights = np.array(self.sampling_weights)
-        self.sampling_weights = self.sampling_weights / np.sum(self.sampling_weights)
+        sampling_weights_array = np.array(sampling_weights)
+        self.sampling_weights = sampling_weights_array / sampling_weights_array.sum()
 
         assert len(self.im_files) == len(self.example_ids)
 

--- a/utils/loggers/tlc/dataset.py
+++ b/utils/loggers/tlc/dataset.py
@@ -5,14 +5,14 @@
 
 from __future__ import annotations
 
-import tlc
+from typing import Any
 
 from utils.loggers.tlc.constants import TLC_TRAIN_PATH, TLC_VAL_PATH
 from utils.loggers.tlc.settings import Settings
 from utils.loggers.tlc.utils import get_names_from_yolo_table, tlc_check_dataset
 
 
-def check_dataset(data_file: str) -> dict[str, tlc.Table | int | dict[str, int]]:
+def check_dataset(data_file: str) -> dict[str, Any]:
     """Load the 3LC dataset (and check for errors) for training."""
     tables = tlc_check_dataset(data_file)
     settings = Settings.from_env()

--- a/utils/loggers/tlc/logger.py
+++ b/utils/loggers/tlc/logger.py
@@ -1,5 +1,6 @@
 # YOLOv5 🚀 AGPL-3.0 license
 """3LC Logger used for training."""
+
 from __future__ import annotations
 
 import os
@@ -9,7 +10,6 @@ from typing import TYPE_CHECKING, Any
 
 import tlc
 import torch
-from tlc.client.utils import batched_iterator
 
 import val as validate
 from models.yolo import DetectionModel
@@ -21,6 +21,7 @@ from utils.loggers.tlc.dataset import check_dataset
 from utils.loggers.tlc.loss import TLCComputeLoss
 from utils.loggers.tlc.settings import Settings
 from utils.loggers.tlc.utils import (
+    batched_iterator,
     create_tlc_info_string_before_training,
     get_metrics_collection_epochs,
     get_names_from_yolo_table,
@@ -69,7 +70,7 @@ class TLCLogger(BaseTLCCallback):
         """Reset the singleton instance of the TLCLogger."""
         cls._instance = None
 
-    def initialize(self, opt=None, hyp=None):
+    def initialize(self, opt=None, hyp: dict[str, Any] | None = None):
         self.opt = opt
         self.hyp = hyp
         self._save_dir = Path(self.opt.save_dir)  # Path to save results
@@ -160,12 +161,15 @@ class TLCLogger(BaseTLCCallback):
     def validation_train_loader(self) -> torch.utils.data.DataLoader:
         if not self._validation_train_loader:
             self._create_validation_train_loader_from_val_loader()
+        assert self._validation_train_loader is not None
         return self._validation_train_loader
 
     @property
     def table(self) -> tlc.Table:
         """Get the table for the current split."""
-        return self.val_table if self._collecting_on == "val" else self.train_table
+        table = self.val_table if self._collecting_on == "val" else self.train_table
+        assert table is not None
+        return table
 
     @property
     def split(self) -> str:
@@ -193,6 +197,7 @@ class TLCLogger(BaseTLCCallback):
 
     def on_train_start(self) -> None:
         # Create a 3LC run and log run parameters
+        assert self.hyp is not None
         self.run = tlc.init(project_name=self.train_table.project_name)
 
         parameters = {k: v for k, v in vars(self.opt).items() if k != "hyp"}
@@ -249,7 +254,8 @@ class TLCLogger(BaseTLCCallback):
         """
         paths = list(last.parent.glob("*.pt"))
         for path in paths:
-            ckpt = torch.load(path, map_location="cpu")
+            # weights_only=False: checkpoints written by this training run contain full model objects
+            ckpt = torch.load(path, map_location="cpu", weights_only=False)
             ckpt["model"].__class__ = DetectionModel
             ckpt["ema"].__class__ = DetectionModel
             torch.save(ckpt, path)
@@ -262,8 +268,8 @@ class TLCLogger(BaseTLCCallback):
         """
         if self._settings.image_embeddings_dim != 0:
             LOGGER.info(
-            f"{TLC_COLORSTR}Reducing embeddings to {self._settings.image_embeddings_dim}D with {self._settings.image_embeddings_reducer}, this may take some time..."
-        )
+                f"{TLC_COLORSTR}Reducing embeddings to {self._settings.image_embeddings_dim}D with {self._settings.image_embeddings_reducer}, this may take some time..."
+            )
             self.run.reduce_embeddings_by_foreign_table_url(
                 self.val_table.url,
                 method=self._settings.image_embeddings_reducer,
@@ -295,7 +301,7 @@ class TLCLogger(BaseTLCCallback):
             self.metrics_writer = tlc.MetricsTableWriter(
                 run_url=self.run.url,
                 foreign_table_url=self.train_table.url,
-                column_schemas=self.metrics_schema,
+                schema=self.metrics_schema,
             )
             effective_train_size = self.validation_train_loader.dataset.n
             self.example_ids_for_batch = list(
@@ -360,13 +366,11 @@ class TLCLogger(BaseTLCCallback):
         self.metrics_writer = tlc.MetricsTableWriter(
             run_url=self.run.url,
             foreign_table_url=self.val_table.url,
-            column_schemas=self.metrics_schema,
+            schema=self.metrics_schema,
         )
         effective_validation_size = self.val_loader.dataset.n
         self.example_ids_for_batch = list(
-            batched_iterator(
-                range(effective_validation_size), batch_size=self._validation_loader_args["batch_size"]
-            )
+            batched_iterator(range(effective_validation_size), batch_size=self._validation_loader_args["batch_size"])
         )
 
     def on_val_batch_end(self, batch_i, images, targets, paths, shapes, outputs, train_out) -> None:

--- a/utils/loggers/tlc/model_utils.py
+++ b/utils/loggers/tlc/model_utils.py
@@ -1,5 +1,6 @@
 # YOLOv5 🚀 AGPL-3.0 license
 """3LC model utils."""
+
 import os
 from typing import Any
 

--- a/utils/loggers/tlc/settings.py
+++ b/utils/loggers/tlc/settings.py
@@ -6,11 +6,12 @@ from __future__ import annotations
 import argparse
 import importlib
 import os
-from dataclasses import dataclass, field, fields
+from dataclasses import Field, dataclass, field, fields
 from difflib import get_close_matches
 from typing import Any
 
-from tlcconfig import options
+# tlcconfig ships no type stubs, so ty cannot resolve its members
+from tlcconfig.options import OptionRegistry  # ty: ignore[unresolved-import]
 
 from utils.general import LOGGER
 from utils.loggers.tlc.constants import TLC_COLORSTR
@@ -115,7 +116,7 @@ class Settings:
             "pacmap",
             "umap",
         ), f"Invalid image embeddings reducer {self.image_embeddings_reducer}."
-        if self.image_embeddings_dim > 0: # Only check reducer if embeddings are enabled
+        if self.image_embeddings_dim > 0:  # Only check reducer if embeddings are enabled
             self._check_reducer_available()
 
         # Train / collect specific settings
@@ -141,9 +142,9 @@ class Settings:
 
         # Collection epoch settings
         assert self.collection_epoch_start >= -1, f"Invalid collection start epoch {self.collection_epoch_start}."
-        assert (
-            self.collection_epoch_interval > 0
-        ), f"Invalid collection epoch interval {self.collection_epoch_interval}."
+        assert self.collection_epoch_interval > 0, (
+            f"Invalid collection epoch interval {self.collection_epoch_interval}."
+        )
 
         # --noval and disabled collection
         assert not (opt.noval and self.collection_disable), "Cannot use --noval and disable collection."
@@ -171,7 +172,7 @@ class Settings:
             )
 
     @staticmethod
-    def _field_to_env_var(_field: field) -> None:
+    def _field_to_env_var(_field: Field[Any]) -> str:
         """
         Return the environment variable name for a given field.
 
@@ -189,19 +190,28 @@ class Settings:
         supported_env_vars = {self._field_to_env_var(_field) for _field in fields(Settings)}
         unsupported_env_vars = {var for var in os.environ if var.startswith("TLC_")} - supported_env_vars
 
-        # Do not warn about `tlcconfig` environment variables, as they are not part of the integration settings
-        tlc_env_vars = {option.envvar for option in options.OPTION.__subclasses__() if option.envvar}
-        unsupported_env_vars = unsupported_env_vars - tlc_env_vars
+        # Do not warn about `tlcconfig` environment variables, as they are not part of the integration settings.
+        # An option's envvar is either a string or a compiled pattern (e.g. for TLC_ALIAS_*).
+        tlc_env_vars = set()
+        tlc_env_var_patterns = []
+        for option in OptionRegistry.all().values():
+            for envvar in (option.envvar, *option.envvar_aliases):
+                if isinstance(envvar, str):
+                    tlc_env_vars.add(envvar)
+                elif envvar is not None:
+                    tlc_env_var_patterns.append(envvar)
 
-        # Do not warn about TLC_ALIAS_* environment variables
-        tlc_alias_env_vars = {var for var in os.environ if var.startswith("TLC_ALIAS_")}
-        unsupported_env_vars = unsupported_env_vars - tlc_alias_env_vars
+        unsupported_env_vars = {
+            var
+            for var in unsupported_env_vars
+            if var not in tlc_env_vars and not any(pattern.fullmatch(var) for pattern in tlc_env_var_patterns)
+        }
 
         # Output all environment variables if there are any unsupported ones
         if len(unsupported_env_vars) > 1:
             LOGGER.warning(
-                f'{TLC_COLORSTR}Found unsupported environment variables: '
-                f'{", ".join(unsupported_env_vars)}.\n{self._supported_env_vars_str()}'
+                f"{TLC_COLORSTR}Found unsupported environment variables: "
+                f"{', '.join(unsupported_env_vars)}.\n{self._supported_env_vars_str()}"
             )
 
         # If there is only one, look for the most similar one
@@ -230,9 +240,11 @@ class Settings:
 
         # Display defaults differently for environment variables as they are provided differently
         if self._from_env:
+
             def formatter(x):
                 return x if not isinstance(x, list) else ",".join(x)
         else:
+
             def formatter(x):
                 return x
 

--- a/utils/loggers/tlc/utils.py
+++ b/utils/loggers/tlc/utils.py
@@ -3,21 +3,36 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Iterable, Iterator
+from itertools import islice
 from pathlib import Path
 from typing import TypeVar
 
 import tlc
 import yaml
-from tlc.client.torch.metrics.metrics_collectors.bounding_box_metrics_collector import (
-    _TLCPredictedBoundingBox,
-    _TLCPredictedBoundingBoxes,
-)
+from tlc.helpers import AnnotationHelper, AnnotationType, SchemaHelper
+from tlc_ultralytics import create_tables_from_yaml_file
+from tlc_ultralytics.detect.utils import check_det_table
+from tlc_ultralytics.utils.dataset import parse_3lc_yaml_file
 
 from utils.general import LOGGER, check_dataset
-from utils.loggers.tlc.constants import TLC_COLORSTR, TLC_PREFIX, TRAINING_PHASE
+from utils.loggers.tlc.constants import TLC_COLORSTR, TLC_PREFIX
 
-T = TypeVar("T", bound=Callable)  # Generic type for environment variable parsing functions
+T = TypeVar("T")
+
+
+def batched_iterator(iterable: Iterable[T], batch_size: int) -> Iterator[list[T]]:
+    """
+    Yield successive batches from an iterable. The last batch may be smaller than batch_size.
+
+    Replaces `tlc.client.utils.batched_iterator`, which was removed in 3lc 3.0.
+
+    :param iterable: The iterable to batch.
+    :param batch_size: The number of items per batch.
+    """
+    iterator = iter(iterable)
+    while batch := list(islice(iterator, batch_size)):
+        yield batch
 
 
 def yolo_predicted_bounding_box_schema(categories: dict[int, str]) -> tlc.Schema:
@@ -27,46 +42,11 @@ def yolo_predicted_bounding_box_schema(categories: dict[int, str]) -> tlc.Schema
     :param categories: Categories for the current dataset.
     :returns: The YOLO bounding box schema for predicted boxes.
     """
-    label_value_map = {float(i): tlc.MapElement(class_name) for i, class_name in categories.items()}
+    from tlc_ultralytics.detect.utils import yolo_predicted_bounding_box_schema as predicted_bounding_box_schema
 
-    bounding_box_schema = tlc.BoundingBoxListSchema(
-        label_value_map=label_value_map,
-        x0_number_role=tlc.NUMBER_ROLE_BB_CENTER_X,
-        x1_number_role=tlc.NUMBER_ROLE_BB_SIZE_X,
-        y0_number_role=tlc.NUMBER_ROLE_BB_CENTER_Y,
-        y1_number_role=tlc.NUMBER_ROLE_BB_SIZE_Y,
-        x0_unit=tlc.UNIT_RELATIVE,
-        y0_unit=tlc.UNIT_RELATIVE,
-        x1_unit=tlc.UNIT_RELATIVE,
-        y1_unit=tlc.UNIT_RELATIVE,
-        description="Predicted Bounding Boxes",
-        writable=False,
-        is_prediction=True,
-        include_segmentation=False,
-    )
+    label_value_map = {float(i): tlc.schemas.MapElement(class_name) for i, class_name in categories.items()}
 
-    return bounding_box_schema
-
-
-def training_phase_schema() -> tlc.Schema:
-    return tlc.Schema(
-        display_name=TRAINING_PHASE,
-        description=(
-            "'During' metrics are collected with EMA during training, "
-            "'After' is with the final model weights after completed training."
-        ),
-        display_importance=tlc.DISPLAY_IMPORTANCE_EPOCH - 1,  # Right hand side of epoch in the Dashboard
-        writable=False,
-        computable=False,
-        value=tlc.Int32Value(
-            value_min=0,
-            value_max=1,
-            value_map={
-                float(0): tlc.MapElement(display_name="During"),
-                float(1): tlc.MapElement(display_name="After"),
-            },
-        ),
-    )
+    return predicted_bounding_box_schema(label_value_map)
 
 
 def yolo_loss_schemas(num_classes: int) -> dict[str, tlc.Schema]:
@@ -76,76 +56,11 @@ def yolo_loss_schemas(num_classes: int) -> dict[str, tlc.Schema]:
     :returns: The YOLO loss schemas.
     """
     schemas = {}
-    schemas["box_loss"] = tlc.Schema(
-        description="Box loss", writable=False, value=tlc.Float32Value(), display_importance=3004
-    )
-    schemas["obj_loss"] = tlc.Schema(
-        description="Object loss", writable=False, value=tlc.Float32Value(), display_importance=3005
-    )
+    schemas["box_loss"] = tlc.schemas.Float32Schema(description="Box loss", writable=False)
+    schemas["obj_loss"] = tlc.schemas.Float32Schema(description="Object loss", writable=False)
     if num_classes > 1:
-        schemas["cls_loss"] = tlc.Schema(
-            description="Classification loss", writable=False, value=tlc.Float32Value(), display_importance=3006
-        )
+        schemas["cls_loss"] = tlc.schemas.Float32Schema(description="Classification loss", writable=False)
     return schemas
-
-
-def yolo_image_embeddings_schema(activation_size=512) -> dict[str, tlc.Schema]:
-    """
-    Create a 3LC schema for YOLOv5 image embeddings.
-
-    :param activation_size: The size of the activation tensor.
-    :returns: The YOLO image embeddings schema.
-    """
-    embedding_schema = tlc.Schema(
-        "Embedding",
-        "Large NN embedding",
-        writable=False,
-        computable=False,
-        value=tlc.Float32Value(number_role=tlc.NUMBER_ROLE_NN_EMBEDDING),
-        size0=tlc.DimensionNumericValue(
-            value_min=activation_size, value_max=activation_size, enforce_min=True, enforce_max=True
-        ),
-    )
-    return {"embeddings": embedding_schema}
-
-
-def construct_bbox_struct(
-    predicted_annotations: list[dict[str, int | float | dict[str, float]]],
-    image_width: int,
-    image_height: int,
-    inverse_label_mapping: dict[int, int] | None = None,
-) -> _TLCPredictedBoundingBoxes:
-    """
-    Construct a 3LC bounding box struct from a list of bounding boxes.
-
-    :param predicted_annotations: A list of predicted bounding boxes.
-    :param image_width: The width of the image.
-    :param image_height: The height of the image.
-    :param inverse_label_mapping: A mapping from predicted label to category id.
-    """
-
-    bbox_struct = _TLCPredictedBoundingBoxes(
-        bb_list=[],
-        image_width=image_width,
-        image_height=image_height,
-    )
-
-    for pred in predicted_annotations:
-        bbox, label, score, iou = pred["bbox"], pred["category_id"], pred["score"], pred["iou"]
-        label_val = inverse_label_mapping[label] if inverse_label_mapping is not None else label
-        bbox_struct["bb_list"].append(
-            _TLCPredictedBoundingBox(
-                label=label_val,
-                confidence=score,
-                iou=iou,
-                x0=bbox[0],
-                y0=bbox[1],
-                x1=bbox[2],
-                y1=bbox[3],
-            )
-        )
-
-    return bbox_struct
 
 
 def get_metrics_collection_epochs(start: int, epochs: int, interval: int, disable: bool) -> list[int]:
@@ -189,133 +104,10 @@ def create_tlc_info_string_before_training(metrics_collection_epochs: list[int],
     else:
         plural_epochs = len(metrics_collection_epochs) > 1
         mc_epochs_str = ",".join(map(str, metrics_collection_epochs))
-        tlc_mc_string = f'Collecting metrics for epoch{"s" if plural_epochs else ""} {mc_epochs_str}'
+        tlc_mc_string = f"Collecting metrics for epoch{'s' if plural_epochs else ''} {mc_epochs_str}"
         tlc_mc_string += " and after training for this run."
 
     return tlc_mc_string
-
-
-def get_or_create_3lc_table_from_yolo(yolo_yaml_file: tlc.Url | str, split: str, override_split_path: str) -> tlc.Table:
-    """
-    Get or create a 3LC table from a YOLO YAML file.
-
-    :param yolo_yaml_file: The path to the YOLO YAML file.
-    :param split: The split to get the table for.
-    :param override_split_path: The path to override the split path in the YAML file.
-    :returns: The 3LC table.
-    """
-    # Resolving logic for YOLO YAML file
-    dataset_name_base = Path(yolo_yaml_file).stem
-    dataset_name = dataset_name_base + "-" + split
-    project_name = "yolov5-" + dataset_name_base
-
-    yolo_yaml_name = Path(yolo_yaml_file).name
-    yolo_yaml_file = str(Path(yolo_yaml_file).resolve())  # Ensure absolute path for resolving Table Url
-
-    # Previously the table name was the split name and now it is "initial", so we need to check for backwards compatibility
-    table_url_backcompatible = tlc.Table._resolve_table_url(
-        table_url=None,
-        root_url=None,
-        project_name=project_name,
-        dataset_name=dataset_name,
-        table_name=split,
-    )
-
-    if table_url_backcompatible.exists():
-        table_name = split
-    else:
-        table_name = "initial"
-
-    try:
-        table = tlc.Table.from_yolo(
-            dataset_yaml_file=yolo_yaml_file,
-            split=split,
-            override_split_path=override_split_path,
-            structure=None,
-            table_name=table_name,
-            dataset_name=dataset_name,
-            project_name=project_name,
-            if_exists="raise",
-            add_weight_column=True,
-            description=f"Created with YOLOv5 integration from {yolo_yaml_name}",
-        )
-        table.write_to_row_cache(create_url_if_empty=True, overwrite_if_exists=False)  # Always cache for YOLO tables
-        LOGGER.info(f"{TLC_COLORSTR}Created {split} table {table.url} from YAML file {yolo_yaml_file}")
-
-    except FileExistsError:
-        # Table already exists, reuse it instead and log it
-        table = tlc.Table.from_yolo(
-            dataset_yaml_file=yolo_yaml_file,
-            split=split,
-            override_split_path=override_split_path,
-            structure=None,
-            table_name=table_name,
-            dataset_name=dataset_name,
-            project_name=project_name,
-            if_exists="reuse",
-            add_weight_column=True,
-            description=f"Created with YOLOv5 integration from {yolo_yaml_name}",
-        )
-        latest_table = table.latest()
-
-        if latest_table == table:
-            LOGGER.info(f"{TLC_COLORSTR}Using existing {split} table for YAML file {yolo_yaml_file}: {table.url}")
-        else:
-            LOGGER.info(f"{TLC_COLORSTR}Using latest {split} table from YAML file {yolo_yaml_file}: {latest_table.url}")
-
-        # Always use the latest table for YOLO YAML based tables
-        table = latest_table
-
-    return table
-
-
-def get_tlc_table_from_url(table_url: tlc.Url, split: str) -> tlc.Table:
-    """
-    Get a 3LC table from a URL.
-
-    :param table_url: The Url of the table.
-    :param split: The split the table corresponds to.
-    :returns: The 3LC table.
-    :raises: ValueError if the table does not exist.
-    :raises: ValueError if the table is not compatible with YOLOv5.
-    """
-
-    try:
-        table = tlc.Table.from_url(table_url)
-        LOGGER.info(f"{TLC_COLORSTR}Using {split} revision {table_url}")
-    except FileNotFoundError:
-        raise ValueError(f"Could not find Table {table_url} for {split} split")
-
-    try:
-        check_table_compatibility(table)
-    except AssertionError as e:
-        raise ValueError(f"Table {table_url} is not compatible with YOLOv5") from e
-
-    table.ensure_fully_defined()
-    return table
-
-
-def check_table_compatibility(table: tlc.Table) -> bool:
-    """
-    Check that the 3LC Table is compatible with YOLOv5.
-
-    :param table: The 3LC Table to check.
-    :returns: True if the Table is compatible, False otherwise.
-    """
-
-    row_schema = table.row_schema.values
-    assert tlc.IMAGE in row_schema, f"Table does not contain an image column {tlc.IMAGE}"
-    assert tlc.WIDTH in row_schema, f"Table does not contain a width column {tlc.WIDTH}"
-    assert tlc.HEIGHT in row_schema, f"Table does not contain a height column {tlc.HEIGHT}"
-    assert tlc.BOUNDING_BOXES in row_schema, "Table does not contain a bounding box column"
-    assert tlc.BOUNDING_BOX_LIST in row_schema[tlc.BOUNDING_BOXES].values, "Bounding box column does not contain a bounding box list"
-    assert tlc.SAMPLE_WEIGHT in row_schema, f"Table does not contain a sample weight column {tlc.SAMPLE_WEIGHT}"
-    assert tlc.LABEL in row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values, f"Bounding box list does not contain a label {tlc.LABEL}"
-
-    for coordinate in [tlc.X0, tlc.Y0, tlc.X1, tlc.Y1]:
-        assert coordinate in row_schema[tlc.BOUNDING_BOXES].values[tlc.BOUNDING_BOX_LIST].values, f"Bounding box list does not contain a {coordinate}"
-
-    return True
 
 
 def write_3lc_yaml(data_file: str, tables: dict[str, tlc.Table]) -> None:
@@ -340,7 +132,7 @@ def write_3lc_yaml(data_file: str, tables: dict[str, tlc.Table]) -> None:
     split_paths_latest = {split: f"{path}:latest" for split, path in split_paths.items()}
 
     # Create 3LC yaml file
-    new_yaml_url.write(yaml.dump(split_paths_latest, sort_keys=False, encoding="utf-8"))
+    new_yaml_url.write_text(yaml.dump(split_paths_latest, sort_keys=False))
 
     LOGGER.info(
         f"{TLC_COLORSTR}Created 3LC YAML file: {str(new_yaml_url)}. To use this file,"
@@ -369,52 +161,43 @@ def tlc_check_dataset(data_file: str, get_splits: tuple | list = ("train", "val"
                 "YOLOv5 dataset check failed. If you are using a 3LC YAML file, remember the 3LC:// prefix."
             ) from e
 
-        # data_file_content = yaml.safe_load(data_file_url.read())
-        tables = {}
-        for key in ("train", "val", "test"):
-            if key in data_dict and data_dict[key]:
-                tables[key] = get_or_create_3lc_table_from_yolo(data_file, split=key, override_split_path=data_dict[key])
+        splits = [key for key in ("train", "val", "test") if data_dict.get(key)]
+        yolo_yaml_name = Path(data_file).name
+
+        tables = create_tables_from_yaml_file(
+            data_file,
+            task="detect",
+            project_name="yolov5-" + Path(data_file).stem,
+            splits=splits,
+            description=f"Created with YOLOv5 integration from {yolo_yaml_name}",
+        )
 
         # Write all tables to the 3LC YAML file
         write_3lc_yaml(data_file, tables)
+
+        # Always use the latest table for YOLO YAML based tables
+        for split, table in tables.items():
+            latest_table = table.latest()
+            if latest_table != table:
+                LOGGER.info(f"{TLC_COLORSTR}Using latest {split} table from YAML file {data_file}: {latest_table.url}")
+            tables[split] = latest_table
 
         # Remove any tables that are not in get_splits
         tables = {split: table for split, table in tables.items() if split in get_splits}
 
     # 3LC YAML file
     else:
-        # Read the YAML file, removing the prefix
-        if not (data_file_url := tlc.Url(data_file.replace(TLC_PREFIX, ""))).exists():
-            raise FileNotFoundError(f"Could not find YAML file {data_file_url}")
+        tables = parse_3lc_yaml_file(data_file)
+        tables = {split: table for split, table in tables.items() if split in get_splits}
 
-        data_config = yaml.safe_load(data_file_url.read())
+        for split, table in tables.items():
+            try:
+                check_det_table(table)
+            except ValueError as e:
+                raise ValueError(f"Table {table.url} is not compatible with YOLOv5") from e
 
-        path = data_config.get("path")
-        splits = [key for key in data_config if key != "path"]
-
-        tables = {}
-        for split in splits:
-            if split not in get_splits:
-                continue
-
-            split_path = data_config[split]
-            latest = split_path.endswith(":latest")
-
-            if latest:
-                split_path = data_config[split][:-7]
-
-            url = tlc.Url(path) / split_path if path else tlc.Url(split_path)
-
-            table = get_tlc_table_from_url(table_url=url, split=split)
-
-            # Use latest revision if :latest is specified
-            if latest:
-                prev_url = url
-                table = table.latest()
-                if prev_url != table.url:
-                    LOGGER.info(f"{TLC_COLORSTR}Using latest revision for {split} set: {table.url}.")
-
-            tables[split] = table
+            table.ensure_fully_defined()
+            LOGGER.info(f"{TLC_COLORSTR}Using {split} revision {table.url}")
 
     # Check that the tables have the same bounding box value maps
     value_maps = [get_names_from_yolo_table(table) for table in tables.values()]
@@ -423,21 +206,33 @@ def tlc_check_dataset(data_file: str, get_splits: tuple | list = ("train", "val"
     return tables
 
 
-def get_names_from_yolo_table(table: tlc.Table, value_path: str = "bbs.bb_list.label") -> dict[int, str]:
+def get_names_from_yolo_table(table: tlc.Table) -> dict[int, str]:
     """
     Get the category names from a YOLO table.
 
     :param table: The YOLO table.
     :returns: The category names for YOLO.
     """
-    value_map = table.get_value_map(value_path)
-    return {int(k): v["internal_name"] for k, v in value_map.items()}
+    annotation = AnnotationHelper.find(table, type=AnnotationType.BOUNDING_BOXES)
+    if annotation is None or annotation.label_path is None:
+        raise ValueError(f"No bounding box label column found in Table {table.url}.")
+
+    value_map = table.get_value_map(annotation.label_path)
+    if value_map is None:
+        raise ValueError(f"Failed to get value map for Table {table.url}.")
+
+    return SchemaHelper.to_simple_value_map(value_map)
+
 
 def verify_model_table_compatible(model, table: tlc.Table) -> None:
     table_names = get_names_from_yolo_table(table)
 
     # Check that the model and table have the same number of classes
-    assert len(model.names) == len(table_names), "The selected model was trained on a different number of classes than the table. Please select a model with the same number of classes as the table."
+    assert len(model.names) == len(table_names), (
+        "The selected model was trained on a different number of classes than the table. Please select a model with the same number of classes as the table."
+    )
 
     # Check that the model and table have the same exact classes
-    assert model.names == table_names, "The selected model was trained on different classes than the table. Please select a model with the same classes as the table."
+    assert model.names == table_names, (
+        "The selected model was trained on different classes than the table. Please select a model with the same classes as the table."
+    )

--- a/utils/loggers/tlc/version.py
+++ b/utils/loggers/tlc/version.py
@@ -1,24 +1,38 @@
 # YOLOv5 🚀 by Ultralytics, AGPL-3.0 license
 """Utility to check the 3LC version is compatible with the integration."""
 
-import tlc
+import importlib.metadata
+
 from packaging import version
 
-from utils.loggers.tlc.constants import TLC_VERSION_REQUIRED
+from utils.loggers.tlc.constants import TLC_ULTRALYTICS_VERSION_REQUIRED, TLC_VERSION_REQUIRED
+
+INSTALL_COMMAND = (
+    f'pip install --upgrade "3lc>={TLC_VERSION_REQUIRED}" "3lc-ultralytics>={TLC_ULTRALYTICS_VERSION_REQUIRED}"'
+    " --extra-index-url https://pypi.3lc.ai/public/repositories/releases-public"
+)
 
 
 def check_tlc_version() -> None:
     """
-    Check that the available 3LC version is supported.
+    Check that the available 3LC packages are supported by the integration.
 
+    The integration requires both `3lc` and `3lc-ultralytics`, which are published on 3LC's
+    public package index, not on PyPI.
     """
-    required_version = version.parse(TLC_VERSION_REQUIRED)
-    installed_version = version.parse(tlc.__version__)
+    for package, required_str in (("3lc", TLC_VERSION_REQUIRED), ("3lc-ultralytics", TLC_ULTRALYTICS_VERSION_REQUIRED)):
+        try:
+            installed = version.parse(importlib.metadata.version(package))
+        except importlib.metadata.PackageNotFoundError:
+            raise ImportError(
+                f"The 3LC integration requires {package}, which is not installed. Install it with `{INSTALL_COMMAND}`."
+            ) from None
 
-    if installed_version < required_version:
-        installed_str = ".".join(str(part) for part in installed_version.release[:3])
-        raise ValueError(
-            f"You are using 3lc=={installed_str}. "
-            f"This version of the integration is intended for 3lc>={required_version}. "
-            "Please upgrade 3lc with `pip install --upgrade 3lc`."
-        )
+        required = version.parse(required_str)
+        if installed < required:
+            installed_str = ".".join(str(part) for part in installed.release[:3])
+            raise ValueError(
+                f"You are using {package}=={installed_str}. "
+                f"This version of the integration is intended for {package}>={required}. "
+                f"Please upgrade with `{INSTALL_COMMAND}`."
+            )

--- a/utils/loggers/tlc/yolo.py
+++ b/utils/loggers/tlc/yolo.py
@@ -1,5 +1,6 @@
 # YOLOv5 🚀 by Ultralytics, AGPL-3.0 license
 """3LC yolo implementation to collect embeddings."""
+
 import torch
 
 from models.yolo import DetectionModel


### PR DESCRIPTION
Migrates the integration to `3lc` 3.0 / `3lc-ultralytics` 0.3, following the [2.x → 3.x migration guide](https://docs.3lc.ai/3lc/latest/python-package/migration-guide/migrating-from-2.x-to-3.x.html) and delegating to `3lc-ultralytics` wherever the logic is training-loop-agnostic.

## API migration

- **Removed imports replaced**: `tlc.client.*` (batched_iterator → inlined; `_TLCPredictedBoundingBox(es)` → `BoundingBoxes2D`), `tlc.core.*` (`CenteredXYWHBoundingBox` → `BoundingBoxes2D`, `track` → `tqdm`), `BoundingBoxListSchema` / `SampleType` / value classes → `tlc.schemas.*`, top-level constants → `tlc.constants.*`, `Url.read/write` → `read_text/write_text`.
- **Bounding boxes** are read via `tlc.data_types.BoundingBoxes2D` (`from_legacy_row` for pre-3.0 tables, `from_row` for new ones); the annotation column and label path are resolved structurally with `AnnotationHelper`, so both the legacy `bbs.bb_list.label` and new `instances_additional_data.label` layouts work. Image shapes now come from the boxes struct instead of `WIDTH`/`HEIGHT` columns.
- **Table creation** is delegated to `tlc_ultralytics.create_tables_from_yaml_file` (replaces removed `Table.from_yolo`), keeping the `yolov5-{stem}` project naming. The `3LC://` YAML path uses `parse_3lc_yaml_file`, and table compatibility checks use `check_det_table`.
- **Metrics**: `MetricsTableWriter(schema=...)`, `finalize()` now auto-updates the run (manual `update_metrics` + private `ObjectRegistry` cache eviction dropped), `run.add_metrics_data(...)` → `run.add_metrics(...)`.
- **Predicted boxes** reuse `tlc_ultralytics.detect.utils.construct_bbox_struct` and schema; per-box IoU is no longer stored, matching the 3lc-ultralytics integration.
- **Version guard** requires `3lc>=3.0.0` and `3lc-ultralytics>=0.3.0` via package metadata, with the extra-index install command in error messages.

## CI / tests / docs (deferred from #49)

- `ruff format --check` and `ty check` are now gated; pre-existing type errors fixed.
- Tests job installs the full requirements (CPU torch) and runs an import test plus e2e train/collect tests on coco128.
- README Getting Started rewritten for the 3.0 install; DEVELOPMENT.md documents the no-releases policy, CI, and the quarterly upstream-sync runbook.

## Temporary: torch<2.6

torch 2.6 flipped `torch.load` to `weights_only=True`, which upstream YOLOv5 fixed after this fork's merge-base. Until the upstream sync lands, CI and the README pin `torch<2.6` (drop both in the sync PR). The one `torch.load` in fork-owned code now passes `weights_only=False` explicitly.

## Validation

- `ruff check`, `ruff format --check`, `ty check`, `pytest` all green.
- End-to-end on coco128 against an isolated project root: `train.py` (1 epoch — tables created, per-sample + per-class metrics written), `val.py --task collect` (tables reused, both splits), and collect with `TLC_IMAGE_EMBEDDINGS_DIM=2`.